### PR TITLE
release: v1.0.30

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -125,16 +125,16 @@
         },
         {
             "name": "wp-content-framework/presenter",
-            "version": "v1.0.22",
+            "version": "v1.0.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/presenter.git",
-                "reference": "dbe5ba376b85910a2a4cd81001081372fb15c240"
+                "reference": "3168655eb6def5391b1331a8528d114cb92d8bec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/dbe5ba376b85910a2a4cd81001081372fb15c240",
-                "reference": "dbe5ba376b85910a2a4cd81001081372fb15c240",
+                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/3168655eb6def5391b1331a8528d114cb92d8bec",
+                "reference": "3168655eb6def5391b1331a8528d114cb92d8bec",
                 "shasum": ""
             },
             "require": {
@@ -168,7 +168,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/presenter/issues",
-                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.22"
+                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.23"
             },
             "funding": [
                 {
@@ -176,7 +176,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2020-10-26T14:12:40+00:00"
+            "time": "2020-11-02T04:27:25+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (2458111edf6fd7cfce7f52d1bf46a59f765325a6)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/update/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.0 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 21 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.4)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Locking matthiasmullie/minify (1.3.63)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.0)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.1.8)
  - Locking symfony/dependency-injection (v5.1.8)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.1.8)
  - Locking symfony/polyfill-ctype (v1.20.0)
  - Locking symfony/polyfill-php80 (v1.20.0)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.23)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 21 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.5.8)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Downloading matthiasmullie/path-converter (1.1.3)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.0)
  - Downloading symfony/polyfill-ctype (v1.20.0)
  - Downloading symfony/filesystem (v5.1.8)
  - Downloading psr/container (1.0.0)
  - Downloading symfony/service-contracts (v2.2.0)
  - Downloading symfony/polyfill-php80 (v1.20.0)
  - Downloading symfony/deprecation-contracts (v2.2.0)
  - Downloading symfony/dependency-injection (v5.1.8)
  - Downloading symfony/config (v5.1.8)
  - Downloading pdepend/pdepend (2.8.0)
  - Downloading psr/log (1.1.3)
  - Downloading composer/xdebug-handler (1.4.4)
  - Downloading phpmd/phpmd (2.9.1)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  - Downloading matthiasmullie/minify (1.3.63)
  - Downloading wp-content-framework/presenter (v1.0.23)
  0/21 [>---------------------------]   0%
  1/21 [=>--------------------------]   4%
  2/21 [==>-------------------------]   9%
  3/21 [====>-----------------------]  14%
  4/21 [=====>----------------------]  19%
  6/21 [========>-------------------]  28%
  7/21 [=========>------------------]  33%
  8/21 [==========>-----------------]  38%
  9/21 [============>---------------]  42%
 10/21 [=============>--------------]  47%
 11/21 [==============>-------------]  52%
 12/21 [================>-----------]  57%
 13/21 [=================>----------]  61%
 14/21 [==================>---------]  66%
 15/21 [====================>-------]  71%
 16/21 [=====================>------]  76%
 17/21 [======================>-----]  80%
 18/21 [========================>---]  85%
 19/21 [=========================>--]  90%
 20/21 [==========================>-]  95%
 21/21 [============================] 100%  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.0): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.20.0): Extracting archive
  - Installing symfony/filesystem (v5.1.8): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.20.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.1.8): Extracting archive
  - Installing symfony/config (v5.1.8): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.4): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.63): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.23): Extracting archive
 0/9 [>---------------------------]   0%
 9/9 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.0 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 21 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.4)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Locking matthiasmullie/minify (1.3.63)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.0)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.1.8)
  - Locking symfony/dependency-injection (v5.1.8)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.1.8)
  - Locking symfony/polyfill-ctype (v1.20.0)
  - Locking symfony/polyfill-php80 (v1.20.0)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.23)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 21 installs, 0 updates, 0 removals
    0 [>---------------------------]    0 [>---------------------------]  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.0): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.20.0): Extracting archive
  - Installing symfony/filesystem (v5.1.8): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.20.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.1.8): Extracting archive
  - Installing symfony/config (v5.1.8): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.4): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.63): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.23): Extracting archive
 0/9 [>---------------------------]   0%
 9/9 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)