### PR TITLE
release: v1.0.50

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
     "phpmd/phpmd": "^2.9",
-    "squizlabs/php_codesniffer": "^3.5",
+    "squizlabs/php_codesniffer": "^3.6",
     "wp-coding-standards/wpcs": "^2.3",
     "phpcompatibility/phpcompatibility-wp": "^2.1"
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6cc18cef76e3f7067c2bb731a097a9e3",
+    "content-hash": "e9d3f6aab766854170f89dedd2431d1f",
     "packages": [
         {
             "name": "matthiasmullie/minify",
@@ -139,16 +139,16 @@
         },
         {
             "name": "wp-content-framework/presenter",
-            "version": "v1.0.37",
+            "version": "v1.0.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/presenter.git",
-                "reference": "6c959c437b169a58e1ecb506ef21bf169be73bce"
+                "reference": "0a93c168506b7b9d76f6d2876d5fda7995ed7a0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/6c959c437b169a58e1ecb506ef21bf169be73bce",
-                "reference": "6c959c437b169a58e1ecb506ef21bf169be73bce",
+                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/0a93c168506b7b9d76f6d2876d5fda7995ed7a0d",
+                "reference": "0a93c168506b7b9d76f6d2876d5fda7995ed7a0d",
                 "shasum": ""
             },
             "require": {
@@ -182,7 +182,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/presenter/issues",
-                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.37"
+                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.38"
             },
             "funding": [
                 {
@@ -190,7 +190,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2021-03-29T05:52:27+00:00"
+            "time": "2021-04-05T05:29:44+00:00"
         }
     ],
     "packages-dev": [
@@ -740,16 +740,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -792,7 +792,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (a0f6067932a09eff992216b49e17bcb773ce51f8)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/update/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.6 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 21 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.6)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.9.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.6.0)
  - Locking symfony/config (v5.2.4)
  - Locking symfony/dependency-injection (v5.2.6)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.6)
  - Locking symfony/polyfill-ctype (v1.22.1)
  - Locking symfony/polyfill-php80 (v1.22.1)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.38)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 21 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.6.0)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Downloading matthiasmullie/path-converter (1.1.3)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.1)
  - Downloading symfony/polyfill-ctype (v1.22.1)
  - Downloading symfony/filesystem (v5.2.6)
  - Downloading psr/container (1.1.1)
  - Downloading symfony/service-contracts (v2.2.0)
  - Downloading symfony/polyfill-php80 (v1.22.1)
  - Downloading symfony/deprecation-contracts (v2.2.0)
  - Downloading symfony/dependency-injection (v5.2.6)
  - Downloading symfony/config (v5.2.4)
  - Downloading pdepend/pdepend (2.9.0)
  - Downloading psr/log (1.1.3)
  - Downloading composer/xdebug-handler (1.4.6)
  - Downloading phpmd/phpmd (2.9.1)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  - Downloading matthiasmullie/minify (1.3.66)
  - Downloading wp-content-framework/presenter (v1.0.38)
  0/21 [>---------------------------]   0%
  3/21 [====>-----------------------]  14%
  6/21 [========>-------------------]  28%
  8/21 [==========>-----------------]  38%
 12/21 [================>-----------]  57%
 13/21 [=================>----------]  61%
 16/21 [=====================>------]  76%
 21/21 [============================] 100%  - Installing squizlabs/php_codesniffer (3.6.0): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.22.1): Extracting archive
  - Installing symfony/filesystem (v5.2.6): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.22.1): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.6): Extracting archive
  - Installing symfony/config (v5.2.4): Extracting archive
  - Installing pdepend/pdepend (2.9.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.6): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.38): Extracting archive
 0/9 [>---------------------------]   0%
 9/9 [============================] 100%
 9/9 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.6 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 21 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.6)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.9.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.6.0)
  - Locking symfony/config (v5.2.4)
  - Locking symfony/dependency-injection (v5.2.6)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.6)
  - Locking symfony/polyfill-ctype (v1.22.1)
  - Locking symfony/polyfill-php80 (v1.22.1)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.38)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 21 installs, 0 updates, 0 removals
    0 [>---------------------------]    0 [>---------------------------]    0 [>---------------------------]  - Installing squizlabs/php_codesniffer (3.6.0): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.22.1): Extracting archive
  - Installing symfony/filesystem (v5.2.6): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.22.1): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.6): Extracting archive
  - Installing symfony/config (v5.2.4): Extracting archive
  - Installing pdepend/pdepend (2.9.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.6): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.38): Extracting archive
 0/9 [>---------------------------]   0%
 9/9 [============================] 100%
 9/9 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- composer.json
- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)